### PR TITLE
Fixing issue of empty iter in flatten stops prematurely

### DIFF
--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -855,7 +855,7 @@ module {
                         switch (nestedIter.next()) {
                             case (?_iter) {
                                 iter := _iter;
-                                iter.next();
+                                next();
                             };
                             case (_) null;
                         };

--- a/tests/Itertools.Test.mo
+++ b/tests/Itertools.Test.mo
@@ -699,6 +699,7 @@ let success = run([
                     let nestedIter = [
                         [1].vals(),
                         [2, 3].vals(),
+                        [].vals(),
                         [4, 5, 6].vals(),
                     ].vals();
 


### PR DESCRIPTION
Fixing issue of empty iter in flatten stops prematurely